### PR TITLE
Enable Gradle build scan in GitHub Actions workflow

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -39,7 +39,7 @@ jobs:
       env:
         LANGCHAIN4J_CHAT_MODEL_OPENAI_API_KEY: "${{ secrets.LANGCHAIN4J_CHAT_MODEL_OPENAI_API_KEY }}"      
       run: |
-        ./gradlew build --scan
+        ./gradlew build
     - name: "Add Build Scan URL as PR comment"
       uses: actions/github-script@v7
       if: github.event_name == 'pull_request' && failure()

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -30,6 +30,10 @@ jobs:
         distribution: 'temurin'
     - name: Setup Gradle
       uses: gradle/gradle-build-action@v3
+      with:
+        build-scan-publish: true
+        build-scan-terms-of-service-url: "https://gradle.com/terms-of-service"
+        build-scan-terms-of-service-agree: "yes"
     - name: Run build with Gradle wrapper
       id: gradle
       env:

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,16 +2,6 @@ plugins {
     id "com.gradle.enterprise" version "3.16.2"
 }
 
-gradleEnterprise {
-    if (System.getenv("CI") != null) {
-        buildScan {
-            publishAlways()
-            termsOfServiceUrl = "https://gradle.com/terms-of-service"
-            termsOfServiceAgree = "yes"
-        }
-    }
-}
-
 rootProject.name = 'spring-boot-tutorials'
 
 include('batch-rest-repository')


### PR DESCRIPTION
This change enables Gradle build scans in the GitHub Actions workflow by adjusting the "Setup Gradle" step with parameters for publishing the scan and agreement to the terms of service. The Gradle enterprise configuration in settings.gradle was redundant and has been removed for cleaner code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Enhanced Gradle workflow by enabling build scan publication and streamlined terms of service agreement process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->