### PR TITLE
Enable Gradle Dependency Submission

### DIFF
--- a/.github/workflows/gradle-dependency-submission.yml
+++ b/.github/workflows/gradle-dependency-submission.yml
@@ -1,0 +1,30 @@
+# Submits a dependency graph on every push to 'main'
+name: Dependency Submission
+
+on:
+  push:
+    branches:
+    - main
+
+permissions:
+  contents: write
+
+jobs:
+  dependency-submission:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout sources
+      uses: actions/checkout@v4
+
+    - name: Set up the JDK used to run Gradle
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: '21'
+
+    - name: Generate and submit dependency graph
+      uses: gradle/actions/dependency-submission@v3
+      with:
+        build-scan-publish: true
+        build-scan-terms-of-service-url: "https://gradle.com/terms-of-service"
+        build-scan-terms-of-service-agree: "yes"

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -30,10 +30,6 @@ jobs:
         distribution: 'temurin'
     - name: Setup Gradle
       uses: gradle/gradle-build-action@v3
-      with:
-        build-scan-publish: true
-        build-scan-terms-of-service-url: "https://gradle.com/terms-of-service"
-        build-scan-terms-of-service-agree: "yes"
     - name: Run build with Gradle wrapper
       id: gradle
       env:


### PR DESCRIPTION
See [Gradle partners with GitHub on supply chain security](https://blog.gradle.org/gradle-github-partnership-supply-chain-security).