### PR TITLE
Include submodules explicitly

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,19 @@
 rootProject.name = 'spring-boot-tutorials'
 
-file('.').eachDir { directory ->
-    def ignored = ['.git', '.github', '.gradle', '.idea', 'build', 'gradle']
-
-    if (!ignored.contains(directory.name)) include(directory.name)
-}
+include('batch-rest-repository')
+include('batch-skip-step')
+include('cloud-jdbc-env-repo')
+include('data-domain-events')
+include('data-envers-audit')
+include('data-jpa-audit')
+include('data-jpa-filtered-query')
+include('data-mongodb-audit')
+include('data-mongodb-full-text-search')
+include('data-mongodb-tc-data-load')
+include('data-mongodb-transactional')
+include('data-rest-validation')
+include('graphql')
+include('jooq')
+include('langchain4j')
+include('test-execution-listeners')
+include('test-rest-assured')


### PR DESCRIPTION
Commit 26b23bf enable submodules to be automatically detected. That has led to Dependabot ignoring submodules in updating dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded the project's scope with the addition of new modules, enhancing functionality across various aspects such as batch processing, data management, and testing frameworks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->