### PR TITLE
Fix data-mongodb-tc-data-load test error

### DIFF
--- a/data-mongodb-tc-data-load/src/test/java/zin/rashidi/data/mongodb/tc/dataload/user/UserRepositoryTests.java
+++ b/data-mongodb-tc-data-load/src/test/java/zin/rashidi/data/mongodb/tc/dataload/user/UserRepositoryTests.java
@@ -12,7 +12,6 @@ import org.testcontainers.utility.DockerImageName;
 
 import static java.time.Duration.ofMinutes;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.testcontainers.containers.wait.strategy.Wait.forLogMessage;
 import static org.testcontainers.utility.MountableFile.forClasspathResource;
 
 /**
@@ -24,9 +23,8 @@ class UserRepositoryTests {
 
     @Container
     @ServiceConnection
-    private static final MongoDBContainer mongo = new MongoDBContainer(DockerImageName.parse("mongo").withTag("6"))
+    private static final MongoDBContainer mongo = new MongoDBContainer(DockerImageName.parse("mongo").withTag("latest"))
             .withCopyToContainer(forClasspathResource("mongo-init.js"), "/docker-entrypoint-initdb.d/mongo-init.js")
-            .waitingFor(forLogMessage("(?i).*waiting for connections.*", 1))
             .withStartupAttempts(2)
             .withStartupTimeout(ofMinutes(1));
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Updated MongoDB container version to "latest" in testing environment.
	- Removed wait strategy during container initialization in tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->