### PR TITLE
Enable ascii doc slides

### DIFF
--- a/.github/workflows/asciidoctor-ghpages.yml
+++ b/.github/workflows/asciidoctor-ghpages.yml
@@ -24,10 +24,10 @@ jobs:
     - name: asciidoctor-ghpages
       uses: manoelcampos/asciidoctor-ghpages-action@v2
       with:
-        pdf_build: true
+        # pdf_build: true
         # asciidoctor_params: --attribute=nofooter
         # adoc_file_ext: .ascii # default is .adoc
         # source_dir: docs/ # default is .
-        # slides_build: true
+        slides_build: true
         # pre_build:
         # post_build:

--- a/.github/workflows/asciidoctor-ghpages.yml
+++ b/.github/workflows/asciidoctor-ghpages.yml
@@ -25,9 +25,9 @@ jobs:
       uses: manoelcampos/asciidoctor-ghpages-action@v2
       with:
         # pdf_build: true
-        # asciidoctor_params: --attribute=nofooter
+        asciidoctor_params: --attribute=nofooter
         # adoc_file_ext: .ascii # default is .adoc
         # source_dir: docs/ # default is .
-        slides_build: true
+        # slides_build: true
         # pre_build:
         # post_build:

--- a/test-rest-assured/README.adoc
+++ b/test-rest-assured/README.adoc
@@ -3,7 +3,6 @@
 Rashidi Zin <rashidi@zin.my>
 1.1, November 16, 2024: Fix broken build
 :toc:
-:navtitle:
 :icons: font
 :url-quickref: https://github.com/rashidi/spring-boot-tutorials/tree/master/test-rest-assured
 

--- a/test-rest-assured/README.adoc
+++ b/test-rest-assured/README.adoc
@@ -3,7 +3,7 @@
 Rashidi Zin <rashidi@zin.my>
 1.1, November 16, 2024: Fix broken build
 :toc:
-:nofooter:
+:navtitle:
 :icons: font
 :url-quickref: https://github.com/rashidi/spring-boot-tutorials/tree/master/test-rest-assured
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Pages workflow to disable PDF builds and enable slide builds for improved documentation presentation.
- **Documentation**
	- Revised README to enhance guidance on Behavior Driven Development (BDD) with RestAssured, including detailed test scenarios for user creation, retrieval, and deletion, as well as improved exception handling explanations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->